### PR TITLE
Bc loss in training

### DIFF
--- a/iq_learn/conf/method/iq.yaml
+++ b/iq_learn/conf/method/iq.yaml
@@ -16,3 +16,5 @@ method:
   mix_coeff: 1
   bc_init: False
   enable_bc_critic_update: False
+  enable_bc_actor_update: False
+  bc_alpha: 0.5

--- a/iq_learn/dataset/expert_dataset.py
+++ b/iq_learn/dataset/expert_dataset.py
@@ -82,7 +82,7 @@ class ExpertDataset(Dataset):
             # Load data from single file.
             with open(cond_location, 'rb') as f:
                 conds = read_file(cond_location, f)
-        self.conds = conds["emb"][:num_trajectories]
+        self.conds = conds["emb"]
         # print("conds length: ", len(self.conds))
         # print("trajectories length: ", len(self.trajectories["states"]))
         # apply permutation to cond
@@ -155,10 +155,9 @@ def load_trajectories(expert_location: str,
             # if not torch.is_tensor(v):
             #     v = np.array(v)  # convert to numpy array
             trajs[k] = [v[i] for i in idx]
-
     else:
         raise ValueError(f"{expert_location} is not a valid path")
-    return trajs, perm
+    return trajs, idx
 
 
 def read_file(path: str, file_handle: IO[Any]) -> Dict[str, Any]:

--- a/iq_learn/train_iq.py
+++ b/iq_learn/train_iq.py
@@ -73,7 +73,7 @@ def main(cfg: DictConfig):
     eval_env = make_env(args)
 
     # Seed envs
-    env.seed(args.seed) 
+    env.seed(args.seed)
     eval_env.seed(args.seed + 10)
 
     REPLAY_MEMORY = int(env_args.replay_mem)
@@ -81,7 +81,6 @@ def main(cfg: DictConfig):
     EPISODE_STEPS = int(env_args.eps_steps)
     EPISODE_WINDOW = int(env_args.eps_window)
     LEARN_STEPS = int(env_args.learn_steps)
-
 
     agent = make_agent(env, args)
     if args.pretrain:
@@ -130,14 +129,17 @@ def main(cfg: DictConfig):
     begin_learn = False
     episode_reward = 0
 
-    # BC initialization
-    if args.method.bc_init:
-        agent.bc_update = types.MethodType(bc_update, agent)
+    # bc loss function
+    if args.method.enable_bc_actor_update:
         agent.loss_calculator = BehaviorCloningLossCalculator(
             ent_weight=1e-3,  # args.method.bc_ent_weight,
             l2_weight=0.0,  # args.method.bc_l2_weight,
         )
+        agent.bc_alpha = args.method.bc_alpha
 
+    # BC initialization
+    if args.method.bc_init:
+        agent.bc_update = types.MethodType(bc_update, agent)
         for learn_steps_bc in count():
             expert_batch = expert_memory_replay.get_samples(
                 agent.batch_size, agent.device
@@ -531,30 +533,27 @@ def iq_update(self, policy_buffer, expert_buffer, logger, step, cond_type):
 
     if self.actor and step % self.actor_update_frequency == 0:
         if not self.args.agent.vdice_actor:
-
-            def change_shape(online, expert):
-                shape = online.shape
-                expert = torch.reshape(expert, shape)
-                return expert
-
             if self.args.offline:
                 obs = expert_batch[0]
                 cond = expert_batch[-1]
+                act_demo = expert_batch[2]
             else:
                 # Use both policy and expert observations
                 obs = torch.cat([policy_batch[0], expert_batch[0]], dim=0)
                 cond = torch.cat([policy_batch[-1], expert_batch[-1]], dim=0)
+                act_demo = expert_batch[2]
+            if not self.args.method.enable_bc_actor_update:
+                act_demo = None
 
             if self.args.num_actor_updates:
                 for i in range(self.args.num_actor_updates):
-                    # actor_alpha_losses = self.update_actor_and_alpha(obs, logger, step)
                     if cond_type == "none":
                         actor_alpha_losses = self.update_actor_and_alpha(
-                            obs, logger, step
+                            obs, act_demo, logger, step
                         )
                     else:
                         actor_alpha_losses = self.update_actor_and_alpha(
-                            (obs, cond), logger, step
+                            (obs, cond), act_demo, logger, step
                         )
 
             losses.update(actor_alpha_losses)
@@ -570,12 +569,10 @@ def iq_update(self, policy_buffer, expert_buffer, logger, step, cond_type):
 def bc_update(self, observation, action, condition, logger, step, cond_type):
     # SAC version
     if self.actor:
-        if cond_type == 'none':
+        if cond_type == "none":
             training_metrics = self.loss_calculator(self, observation, action)
         else:
-            training_metrics = self.loss_calculator(
-                self, (observation, condition), action
-            )
+            training_metrics = self.loss_calculator(self, (observation, condition), action)
 
         loss = training_metrics["loss/bc_actor"]
 

--- a/iq_learn/train_iq.py
+++ b/iq_learn/train_iq.py
@@ -149,7 +149,7 @@ def main(cfg: DictConfig):
                 expert_cond,
                 logger,
                 learn_steps_bc,
-                args.cond_dim,
+                args.cond_type,
             )
 
             # log losses
@@ -567,10 +567,10 @@ def iq_update(self, policy_buffer, expert_buffer, logger, step, cond_type):
     return losses
 
 
-def bc_update(self, observation, action, condition, logger, step, cond_dim):
+def bc_update(self, observation, action, condition, logger, step, cond_type):
     # SAC version
     if self.actor:
-        if cond_dim == -2:
+        if cond_type == 'none':
             training_metrics = self.loss_calculator(self, observation, action)
         else:
             training_metrics = self.loss_calculator(
@@ -586,7 +586,7 @@ def bc_update(self, observation, action, condition, logger, step, cond_dim):
 
         # update critic
         # if step % self.actor_update_frequency == 0:
-        #     if cond_dim==-2:
+        #     if cond_type == 'none':
         #         critic_losses = self.bc_update_critic(observation, logger, step)
         #     else:
         #         critic_losses = self.bc_update_critic((observation, condition), logger, step)


### PR DESCRIPTION
Fix issues: 
* indices of conditions and trajectories do not match: load_trajectories() should return `idx` rather than `perm` in iq_learn/dataset/expert_dataset.py
* I should have fixed this. Please double check. 

New features: 
* Implement behavioral learning (BC) loss during training
* To enable it, set `method.enable_bc_actor_update=True`
* Other optional arguments:
   * `method.bc_init`: whether enabling BC intitialization
   * `method.bc_alpha`: the weight of the BC loss in the actor loss, default 0.5
